### PR TITLE
fix(docker): point COPY to pipeline requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY requirements.txt requirements.txt
+COPY pipeline/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## Summary
- fix path for requirements in Dockerfile to use `pipeline/requirements.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687942e1edfc8325b881fb0e3f348436